### PR TITLE
Add way to export images via CLI

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto

--- a/app/code/community/Arkade/S3/etc/config.xml
+++ b/app/code/community/Arkade/S3/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
     <modules>
         <Arkade_S3>
-            <version>0.1.0</version>
+            <version>1.1.0</version>
         </Arkade_S3>
     </modules>
     <global>

--- a/modman
+++ b/modman
@@ -1,3 +1,3 @@
 app/code/community/Arkade/* app/code/community/Arkade/
 app/etc/modules/*           app/etc/modules/
-shell/8                     shell/
+shell/*                     shell/

--- a/modman
+++ b/modman
@@ -1,2 +1,3 @@
 app/code/community/Arkade/* app/code/community/Arkade/
 app/etc/modules/*           app/etc/modules/
+shell/8                     shell/

--- a/shell/s3.php
+++ b/shell/s3.php
@@ -1,0 +1,43 @@
+<?php
+require_once 'abstract.php';
+
+class Arkade_Shell_S3 extends Mage_Shell_Abstract
+{
+    public function run()
+    {
+        /** @var Mage_Core_Helper_File_Storage $helper */
+        $helper = Mage::helper('core/file_storage');
+
+        // Stop S3 from syncing to itself
+        if (Arkade_S3_Model_Core_File_Storage::STORAGE_MEDIA_S3 == $helper->getCurrentStorageCode()) {
+            return $this;
+        }
+
+        /** @var Mage_Core_Model_File_Storage_File|Mage_Core_Model_File_Storage_Database $sourceModel */
+        $sourceModel = $helper->getStorageModel();
+
+        /** @var Arkade_S3_Model_Core_File_Storage_S3 $destinationModel */
+        $destinationModel = $helper->getStorageModel(Arkade_S3_Model_Core_File_Storage::STORAGE_MEDIA_S3);
+
+        $offset = 0;
+        while (($files = $sourceModel->exportFiles($offset, 1)) !== false) {
+            foreach ($files as $file) {
+                echo $file['directory'] . '/' . $file['filename'] . "\n";
+            }
+            if (!$this->getArgs('dry-run')) {
+                $destinationModel->importFiles($files);
+            }
+            $offset += count($files);
+        }
+        unset($files);
+
+        if (!$this->getArgs('dry-run')) {
+            Mage::getConfig()->saveConfig('system/media_storage_configuration/media_storage', 2);
+        }
+
+        return $this;
+    }
+}
+
+$shell = new Arkade_Shell_S3();
+$shell->run();

--- a/shell/s3_config.php
+++ b/shell/s3_config.php
@@ -1,0 +1,113 @@
+<?php
+require_once './abstract.php';
+
+class Arkade_S3_Shell_Config extends Mage_Shell_Abstract
+{
+    protected function _validate()
+    {
+        if (!isset($this->_args['h']) && !isset($this->_args['help'])) {
+            $errors = [];
+            if (empty($this->getArg('access-key'))) {
+                $errors[] = 'You must specify the "access-key" parameter.';
+            }
+            if (empty($this->getArg('secret-key'))) {
+                $errors[] = 'You must specify the "secret-key" parameter.';
+            }
+            if (empty($this->getArg('bucket'))) {
+                $errors[] = 'You must specify the "bucket" parameter.';
+            }
+            if (empty($this->getArg('region'))) {
+                $errors[] = 'You must specify the "region" parameter.';
+            } else {
+                /** @var Arkade_S3_Helper_S3 $helper */
+                $helper = Mage::helper('arkade_s3/s3');
+                if (!$helper->isValidRegion($this->getArg('region'))) {
+                    $errors[] = sprintf('The region "%s" is invalid.', $this->getArg('region'));
+                }
+            }
+            if (!empty($errors)) {
+                foreach ($errors as $error) {
+                    echo $error . "\n";
+                }
+
+                echo "\nusage: php s3_config.php [options]\n\n";
+                echo "    --access-keyid <access-key-id> a valid AWS access key ID\n";
+                echo "    --secret-key <secret-key>      a valid AWS secret access key\n";
+                echo "    --bucket <bucket>              an S3 bucket name\n";
+                echo "    --region <region>              an S3 region, e.g. us-east-1\n";
+                echo "    -h, --help\n\n";
+                die();
+            }
+
+            parent::_validate();
+        }
+    }
+
+    public function run()
+    {
+        Mage::getConfig()->saveConfig('arkade_s3/general/access_key', $this->getArg('access-key'));
+        Mage::getConfig()->saveConfig('arkade_s3/general/secret_key', $this->getArg('secret-key'));
+        Mage::getConfig()->saveConfig('arkade_s3/general/bucket', $this->getArg('bucket'));
+        Mage::getConfig()->saveConfig('arkade_s3/general/region', $this->getArg('region'));
+
+        echo "You have successfully updated your S3 credentials.\n";
+
+        return $this;
+    }
+
+    /**
+     * Retrieve Usage Help Message
+     *
+     */
+    public function usageHelp()
+    {
+        return <<<USAGE
+\033[1mDESCRIPTION\033[0m
+    Allows the developer to configure which S3 bucket they want to use with
+    their Magento installation.
+
+\033[1mSYNOPSIS\033[0m
+    php s3_config.php [--access-key-id <access-key-id>]
+                      [--secret-key <secret-key>]
+                      [--bucket <bucket>]
+                      [--region <region>]
+                      [-h] [--help]
+
+\033[1mOPTIONS\033[0m
+    --access-key-id <access-key-id>
+        You must provide a valid AWS access key ID. You can generate access keys
+        using the AWS IAM (https://console.aws.amazon.com/iam/home).
+
+    --secret-key <secret-key>
+        You must also provide the secret access key that corresponds to the
+        access key ID that you have just generated.
+
+    --bucket <bucket>
+        You must provide a valid S3 bucket name that you want media files to be
+        uploaded to.
+
+    --region <region>
+        You must provide a valid S3 region. As 2016-03-17, S3 has the following
+        regions:
+
+        us-east-1
+        us-west-1
+        us-west-2
+        eu-west-1
+        eu-central-1
+        ap-southeast-1
+        ap-southeast-2
+        ap-northeast-1
+        ap-northeast-2
+        sa-east-1
+
+        You can review all valid S3 regions via the AWS documentation
+        (http://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region).
+
+
+USAGE;
+    }
+}
+
+$shell = new Arkade_S3_Shell_Config();
+$shell->run();

--- a/shell/s3_export.php
+++ b/shell/s3_export.php
@@ -3,39 +3,85 @@ require_once './abstract.php';
 
 class Arkade_S3_Shell_Export extends Mage_Shell_Abstract
 {
+    protected function _validate()
+    {
+        if ($this->getArg('dry-run') && $this->getArg('force')) {
+            echo "You can't use --dry-run and --force at the same time!\n";
+        }
+
+        parent::_validate();
+    }
+
     public function run()
     {
-        /** @var Mage_Core_Helper_File_Storage $helper */
-        $helper = Mage::helper('core/file_storage');
+        if ($this->getArg('dry-run') || $this->getArg('force')) {
+            /** @var Mage_Core_Helper_File_Storage $helper */
+            $helper = Mage::helper('core/file_storage');
 
-        // Stop S3 from syncing to itself
-        if (Arkade_S3_Model_Core_File_Storage::STORAGE_MEDIA_S3 == $helper->getCurrentStorageCode()) {
-            return $this;
-        }
+            // Stop S3 from syncing to itself
+            if (Arkade_S3_Model_Core_File_Storage::STORAGE_MEDIA_S3 == $helper->getCurrentStorageCode()) {
+                echo "You are already using S3 as your media file storage backend!\n";
 
-        /** @var Mage_Core_Model_File_Storage_File|Mage_Core_Model_File_Storage_Database $sourceModel */
-        $sourceModel = $helper->getStorageModel();
-
-        /** @var Arkade_S3_Model_Core_File_Storage_S3 $destinationModel */
-        $destinationModel = $helper->getStorageModel(Arkade_S3_Model_Core_File_Storage::STORAGE_MEDIA_S3);
-
-        $offset = 0;
-        while (($files = $sourceModel->exportFiles($offset, 1)) !== false) {
-            foreach ($files as $file) {
-                echo $file['directory'] . '/' . $file['filename'] . "\n";
+                return $this;
             }
-            if (!$this->getArg('dry-run')) {
-                $destinationModel->importFiles($files);
-            }
-            $offset += count($files);
-        }
-        unset($files);
 
-        if (!$this->getArg('dry-run')) {
-            Mage::getConfig()->saveConfig('system/media_storage_configuration/media_storage', 2);
+            /** @var Mage_Core_Model_File_Storage_File|Mage_Core_Model_File_Storage_Database $sourceModel */
+            $sourceModel = $helper->getStorageModel();
+
+            /** @var Arkade_S3_Model_Core_File_Storage_S3 $destinationModel */
+            $destinationModel = $helper->getStorageModel(Arkade_S3_Model_Core_File_Storage::STORAGE_MEDIA_S3);
+
+            $offset = 0;
+            while (($files = $sourceModel->exportFiles($offset, 1)) !== false) {
+                foreach ($files as $file) {
+                    echo sprintf("Uploading %s to S3.\n", $file['directory'] . '/' . $file['filename']);
+                }
+                if ($this->getArg('force')) {
+                    $destinationModel->importFiles($files);
+                }
+                $offset += count($files);
+            }
+            unset($files);
+
+            // Update configuration to tell Magento that we are now using S3
+            if ($this->getArg('force')) {
+                echo "Updating configuration to use S3.\n";
+
+                Mage::getConfig()->saveConfig('system/media_storage_configuration/media_storage', 2);
+                Mage::app()->getConfig()->reinit();
+            }
+        } else {
+            echo $this->usageHelp();
         }
 
         return $this;
+    }
+
+    public function usageHelp()
+    {
+        return <<<USAGE
+\033[1mDESCRIPTION\033[0m
+    This script allows the developer to export all media files from the current
+    storage backend, i.e. file system or database, to S3 via the command line.
+
+\033[1mSYNOPSIS\033[0m
+    php s3_export.php [--force]
+                      [--dry-run]
+                      [-h] [--help]
+
+\033[1mOPTIONS\033[0m
+    --force
+        This parameter will legit upload your media files to S3.
+
+        \033[1mNOTE:\033[0m Please make sure to back up your media files before you run this!
+        You never know what might happen!
+
+    --dry-run
+        This parameter will allow developers to simulate exporting media files
+        to S3 without actually uploading anything!
+
+
+USAGE;
     }
 }
 

--- a/shell/s3_export.php
+++ b/shell/s3_export.php
@@ -1,7 +1,7 @@
 <?php
-require_once 'abstract.php';
+require_once './abstract.php';
 
-class Arkade_Shell_S3 extends Mage_Shell_Abstract
+class Arkade_S3_Shell_Export extends Mage_Shell_Abstract
 {
     public function run()
     {
@@ -39,5 +39,5 @@ class Arkade_Shell_S3 extends Mage_Shell_Abstract
     }
 }
 
-$shell = new Arkade_Shell_S3();
+$shell = new Arkade_S3_Shell_Export();
 $shell->run();

--- a/shell/s3_export.php
+++ b/shell/s3_export.php
@@ -24,14 +24,14 @@ class Arkade_S3_Shell_Export extends Mage_Shell_Abstract
             foreach ($files as $file) {
                 echo $file['directory'] . '/' . $file['filename'] . "\n";
             }
-            if (!$this->getArgs('dry-run')) {
+            if (!$this->getArg('dry-run')) {
                 $destinationModel->importFiles($files);
             }
             $offset += count($files);
         }
         unset($files);
 
-        if (!$this->getArgs('dry-run')) {
+        if (!$this->getArg('dry-run')) {
             Mage::getConfig()->saveConfig('system/media_storage_configuration/media_storage', 2);
         }
 


### PR DESCRIPTION
This change adds two shell scripts:

1. You can now configure and view your AWS settings, e.g. access key ID, bucket, region, secret access key, via the command line.  
2. You can now export your media files to S3 via the CLI as well.