### PR TITLE
Fixes no categories or files being returned in WYSIWYG image manager

### DIFF
--- a/app/code/community/Arkade/S3/Model/Core/File/Storage/S3.php
+++ b/app/code/community/Arkade/S3/Model/Core/File/Storage/S3.php
@@ -205,7 +205,7 @@ class Arkade_S3_Model_Core_File_Storage_S3 extends Mage_Core_Model_File_Storage_
         $prefix = Mage::helper('core/file_storage_database')->getMediaRelativePath($path);
         $prefix = rtrim($prefix, '/') . '/';
 
-        $objectsAndPrefixes = $this->getHelper()->getClient()->getObjectsAndPrefixesByBucket($this->getBucket(), [
+        $objectsAndPrefixes = $this->getHelper()->getClient()->getObjectsAndPrefixesByBucket($this->getHelper()->getBucket(), [
             'prefix' => $prefix,
             'delimiter' => '/'
         ]);
@@ -228,7 +228,7 @@ class Arkade_S3_Model_Core_File_Storage_S3 extends Mage_Core_Model_File_Storage_
         $prefix = Mage::helper('core/file_storage_database')->getMediaRelativePath($directory);
         $prefix = rtrim($prefix, '/') . '/';
 
-        $objectsAndPrefixes = $this->getHelper()->getClient()->getObjectsAndPrefixesByBucket($this->getBucket(), [
+        $objectsAndPrefixes = $this->getHelper()->getClient()->getObjectsAndPrefixesByBucket($this->getHelper()->getBucket(), [
             'prefix' => $prefix,
             'delimiter' => '/'
         ]);


### PR DESCRIPTION
$this->getBucket() is used in getSubdirectories, and getDirectoryFiles method, but it returns a null. This leads to WYSIWYG image manager not returning any directories, nor files. Using $this->getHelper()->getBucket() is used in other methods, and using it for the above resolves the issue.